### PR TITLE
Integration tests the due date and duration specifiers for tasks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,13 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go_version: [ "^1", "^1.17" ]
+        go_version: [ "^1", "^1.19" ]
     steps:
       - uses: actions/checkout@v2 # Trusted creator
       - uses: actions/setup-go@v2 # Trusted creator
         with:
           check-latest: true
           go-version: ${{ matrix.go_version }}
+
+      - name: "Install Ginkgo binary"
+        run: cd ../ && go install github.com/onsi/ginkgo/v2/ginkgo@latest
 
       - name: "Run tests"
         run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,13 @@ jobs:
       - uses: actions/setup-go@v2 # Trusted creator
         with:
           check-latest: true
-          go-version: "^1.17"
+          go-version: "^1.19"
+
+      - name: "Install Ginkgo binary"
+        run: cd ../ && go install github.com/onsi/ginkgo/v2/ginkgo@latest
+
+      - name: "Run tests"
+        run: make test
 
       - name: "Compile release"
         run: make dist

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,17 @@ fakes:
 
 ## Test targets
 .PHONY: test
-test: ./vendor/
-	go test ./...
+test: fake.ical fakes unit_test integration_test
+
+.PHONY: unit_test
+unit_test: ./vendor/
+	ginkgo --skip-package "integration_test" ./...
+
+.PHONY: integration_test
+integration_test: $OUT_PATH
+	ginkgo ./integration_test -- --binary "../${OUT_PATH}"
+
+fake.ical: fake-calendar
 
 ## Dev targets
 .PHONY: set-env

--- a/integration_test/integration_test_suite_test.go
+++ b/integration_test/integration_test_suite_test.go
@@ -1,11 +1,78 @@
 package integration_test_test
 
 import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	cmdContext "github.com/AP-Hunt/what-next/m/context"
 )
+
+var binaryLocation string
+
+func init() {
+	flag.StringVar(&binaryLocation, "binary", "./bin/what-next", "Specify the path of the binary to test")
+}
+
+type testConfig struct {
+	Context cmdContext.CommandContext
+	DataDir string
+}
+
+type Executor = func(args []string) error
+
+func RunIntegrationTest(action func(exec Executor, cfg *testConfig)) {
+	tempDir, err := os.MkdirTemp(os.TempDir(), "what-next-integration-test")
+	Expect(err).ToNot(HaveOccurred())
+
+	defer os.RemoveAll(tempDir)
+
+	os.Setenv("WHAT_NEXT_DATA_DIR", ":memory:")
+
+	Expect(path.Join(tempDir, "what-next.sqlite")).
+		ToNot(BeAnExistingFile(), "The database file should not exist at the start of integration testing")
+
+	cfg := &testConfig{
+		DataDir: tempDir,
+	}
+
+	executor := func(args []string) error {
+		binPath, err := filepath.Abs(binaryLocation)
+		Expect(err).ToNot(HaveOccurred())
+
+		cmd := exec.Command(binPath, args...)
+
+		env := os.Environ()
+		env = append(env, fmt.Sprintf("WHAT_NEXT_DATA_DIR=%s", tempDir))
+
+		errBuff := bytes.Buffer{}
+		errBuffWriter := bufio.NewWriter(&errBuff)
+
+		cmd.Env = env
+		cmd.Stdout = GinkgoWriter
+		cmd.Stderr = errBuffWriter
+
+		runErr := cmd.Run()
+
+		if runErr != nil {
+			stdErrContent := errBuff.String()
+			return fmt.Errorf("%s\n%s\n", runErr, stdErrContent)
+		}
+
+		return nil
+	}
+
+	action(executor, cfg)
+}
 
 func TestIntegrationTest(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/integration_test/startup_test.go
+++ b/integration_test/startup_test.go
@@ -1,31 +1,18 @@
 package integration_test_test
 
 import (
-	"context"
-	"os"
 	"path"
 
-	"github.com/AP-Hunt/what-next/m/cmd"
-	cmdContext "github.com/AP-Hunt/what-next/m/context"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Startup", func() {
 	It("will create the database at startup if it doesn't exist yet", func() {
-
-		tempDir, err := os.MkdirTemp(os.TempDir(), "what-next-integration-test")
-		Expect(err).ToNot(HaveOccurred())
-		defer os.RemoveAll(tempDir)
-
-		os.Setenv("WHAT_NEXT_DATA_DIR", tempDir)
-
-		Expect(path.Join(tempDir, "what-next.sqlite")).ToNot(BeAnExistingFile())
-
-		ctx, err := cmdContext.CreateDefaultCommandContext(context.Background())
-		Expect(err).ToNot(HaveOccurred())
-		cmd.ExecuteCWithArgs(ctx, []string{"--version"})
-
-		Expect(path.Join(tempDir, "what-next.sqlite")).To(BeAnExistingFile())
+		RunIntegrationTest(func(exec Executor, cfg *testConfig) {
+			err := exec([]string{"--version"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(path.Join(cfg.DataDir, "what-next.sqlite")).To(BeAnExistingFile())
+		})
 	})
 })

--- a/integration_test/todo_add_test.go
+++ b/integration_test/todo_add_test.go
@@ -1,0 +1,66 @@
+package integration_test_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("todo add", func() {
+	Describe("--duration", func() {
+		DescribeTable("accepts a variety of duration specifiers",
+			func(specifier string) {
+				RunIntegrationTest(func(exec Executor, cfg *testConfig) {
+					err := exec([]string{"todo", "add", "test action", "--duration", specifier})
+					Expect(err).ToNot(HaveOccurred())
+				})
+			},
+			Entry("seconds", "30s"),
+			Entry("minutes", "30m"),
+			Entry("hours", "30h"),
+			Entry("minutes and seconds", "1m30s"),
+			Entry("hours and minutes", "1h30m"),
+		)
+
+		DescribeTable("does not support duration specifiers greater than hours",
+			func(specifier string) {
+				RunIntegrationTest(func(exec Executor, cfg *testConfig) {
+					err := exec([]string{"todo", "add", "test action", "--duration", specifier})
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("unknown unit"))
+				})
+			},
+			Entry("days", "1d"),
+			Entry("weeks", "1w"),
+			Entry("months", "1M"),
+			Entry("years", "1y"),
+		)
+	})
+
+	Describe("--due", func() {
+		DescribeTable("accepts dates in a variety of formats",
+			func(date string) {
+				RunIntegrationTest(func(exec Executor, cfg *testConfig) {
+					err := exec([]string{"todo", "add", "test action", "--due", date})
+					Expect(err).ToNot(HaveOccurred())
+				})
+			},
+			Entry("ISO 8601 date", "2020-01-01"),
+			Entry("ISO 8601 datetime", "2020-01-01T15:30:22+01:00"),
+			Entry("RFC1123", time.Now().Format(time.RFC1123)),
+			Entry("RFC1123Z", time.Now().Format(time.RFC1123Z)),
+			Entry("RFC3339", time.Now().Format(time.RFC3339)),
+			Entry("RFC3339Nano", time.Now().Format(time.RFC3339Nano)),
+			Entry("RFC822", time.Now().Format(time.RFC822)),
+			Entry("RFC822Z", time.Now().Format(time.RFC822Z)),
+			Entry("RFC850", time.Now().Format(time.RFC850)),
+			Entry("ANSIC", time.Now().Format(time.ANSIC)),
+			Entry("@today", "@today"),
+			Entry("@tod", "@tod"),
+			Entry("@tom", "@tom"),
+			Entry("@tmrw", "@tmrw"),
+			Entry("@tomorrow", "@tomorrow"),
+		)
+	})
+})


### PR DESCRIPTION
Also refactors integration tests to invoke the compiled binary instead of running all in memory. This makes it easier to isolate tests from one another, and exercises things more like a user would.